### PR TITLE
install sudo after git, because we need it in the next step.

### DIFF
--- a/install
+++ b/install
@@ -343,7 +343,7 @@ install_pkg() {
 }
 
 install_extra() {
-    local packages=(apt-transport-https ca-certificates curl gnupg2 net-tools nginx software-properties-common sudo tzdata ucspi-tcp zip)
+    local packages=(apt-transport-https ca-certificates curl gnupg2 net-tools nginx software-properties-common tzdata ucspi-tcp zip)
     for package in "${packages[@]}"; do
         install_pkg "$package"
     done
@@ -689,6 +689,7 @@ main() {
     start_temporary_log
     check_root
     install_pkg "git"
+    install_pkg "sudo"
     labca_user
     end_temporary_log
 


### PR DESCRIPTION
I've changed the install order and moved sudo after git, because it's needed in the next step (before installing extra packages)