### PR TITLE
fixed the creation of the hostname-policy.yaml file when use Whitelis…

### DIFF
--- a/gui/apply-boulder
+++ b/gui/apply-boulder
@@ -39,7 +39,7 @@ fi
 if [ "$PKI_DOMAIN_MODE" == "whitelist" ] && [ "$PKI_WHITELIST_DOMAINS" != "" ]; then
     echo >> hostname-policy.yaml
     echo "# Whitelist are the domains that this LabCA instance can issue certificates for" >> hostname-policy.yaml
-    echo "in *addition* to all normal public domains" >> hostname-policy.yaml
+    echo "# in *addition* to all normal public domains" >> hostname-policy.yaml
     echo "Whitelist:" >> hostname-policy.yaml
     for d in $(echo $PKI_WHITELIST_DOMAINS | sed -e "s/\\\r\\\n/ /g" | tr '\r' ' '); do
         echo "  - \"$d\"" >> hostname-policy.yaml


### PR DESCRIPTION
When it generates the hostname-policy.yaml file using the Whitelist option it breaks the file 