### PR TITLE
add install_pkg "patch"

### DIFF
--- a/install
+++ b/install
@@ -856,6 +856,7 @@ main() {
     check_root
     install_pkg "git"
     install_pkg "sudo"
+    install_pkg "patch"
     labca_user
     end_temporary_log
 


### PR DESCRIPTION
on proxmox lxc for debian 11 the patch command is missing and the script will fail

Distributor ID: Debian
Description:    Debian GNU/Linux 11 (bullseye)
Release:        11
Codename:       bullseye