### PR TITLE
fix missing lsb-release dep in some fresh lxc debian 12 container

### DIFF
--- a/install
+++ b/install
@@ -448,7 +448,7 @@ install_pkg() {
 }
 
 install_extra() {
-    local packages=(apt-transport-https ca-certificates curl gnupg net-tools tzdata ucspi-tcp zip python)
+    local packages=(apt-transport-https ca-certificates curl gnupg net-tools tzdata ucspi-tcp zip python lsb-release)
     for package in "${packages[@]}"; do
         install_pkg "$package"
     done


### PR DESCRIPTION
this commit fix this issue into a fresh lib deb12 image: 

```
  [✓] Package 'tzdata' is installed
  [✓] Package 'ucspi-tcp' is installed
  [✓] Package 'zip' is installed
  [✓] Package 'python3' is installed
/home/labca/labca/install: line 456: lsb_release: command not found

  Error: Could not download docker repository key
```