### PR TITLE
fix(gui): add protocol in mysql connection

### DIFF
--- a/gui/main.go
+++ b/gui/main.go
@@ -2460,12 +2460,7 @@ func writeStandaloneConfig(cfg *StandaloneConfig) {
 		conn += ":" + cfg.MySQLPasswd
 	}
 	conn += "@"
-	_, err := strconv.Atoi(string(strings.TrimSpace(cfg.MySQLServer)[0]))
-	if err == nil {
-		conn += "tcp(" + cfg.MySQLServer + ":" + cfg.MySQLPort + ")"
-	} else {
-		conn += cfg.MySQLServer + ":" + cfg.MySQLPort
-	}
+	conn += "tcp(" + cfg.MySQLServer + ":" + cfg.MySQLPort + ")"
 	conn += "/" + cfg.MySQLDBName
 
 	restart := viper.GetBool("server.https") != cfg.UseHTTPS || viper.GetString("server.cert") != cfg.CertPath || viper.GetString("server.key") != cfg.KeyPath


### PR DESCRIPTION
First, thanks for maintaining this tool to create certificates easier. I had an issue when trying to use it with smallsteps step-ca in its standalone version.

When using labca standalone with docker compose like this:

```yaml
services:
  smallstep:
    image: smallstep/step-ca
    restart: unless-stopped
    ports:
      - 9000:9000
    volumes:
      - /mystorage/stepca:/home/step
    environment:
      DOCKER_STEPCA_INIT_NAME: StepCA
      DOCKER_STEPCA_INIT_DNS_NAMES: mydomain
      DOCKER_STEPCA_INIT_PROVISIONER_NAME: admin
    depends_on:
      - db
  web:
    image: ghcr.io/hakwerk/labca-standalone
    ports:
      - 3000:3000
    volumes:
      - /mystorage/labca/config/stepca_config.json:/usr/data/config.json
    depends_on:
      - db
  db:
    user: 3020:3020
    image: mysql
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: rootpassword
      MYSQL_DATABASE: stepca
      MYSQL_USER: stepca
      MYSQL_PASSWORD: userpassword
      MYSQL_TCP_PORT: 3306
    volumes:
      - /mystorage/labca/db:/var/lib/mysql
    healthcheck:
      test:
        - CMD
        - mysqladmin
        - ping
        - -h
        - localhost
        - -uroot
        - -prootpassword
      interval: 10s
      timeout: 5s
      retries: 5
networks: {}
```

in `/mystorage/stepca/config/ca.json` add
```json
"db": {
        "type": "mysql",
        "dataSource": "labcauser:userpassword@tcp(db:3306)/",
        "database": "stepca"
},
```

The Lab CA UI setup wizard asks for the MySQL connection host. In a setup like this, it is expected that the host is "db", the name of the docker container. However, as I understand it, the code expects an ip address (checks for a number in first position) in which case it will add the required "tcp" protocol in the mysql connection url. Since "db" does not start with a digit, it does not add the "tcp" protocol part to the url and the connection fails. There is as far as I can tell no way to prevent this behaviour in the setup GUI, hence I'm providing this proposed fix.

I just don't know if there is any valid use case in which the protocol should be omitted for mysql. I tested this, and it works with a setup like above.

PS. It might be useful to add the above docker-compose example to the documentation for the standalone server, to get started quicker.
