### PR TITLE
Fix ARM64 local deployment and report stability validation

### DIFF
--- a/build/.env.sample
+++ b/build/.env.sample
@@ -1,2 +1,4 @@
 # You can use a .env file to set variables used in the docker-compose.yml file, e.g.:
 LABCA_FQDN=ca.test.internal
+LABCA_IMAGE_PLATFORM=linux/amd64
+LABCA_FAKE_DNS=10.77.77.9

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     # dev environments. In CI a specific BOULDER_TOOLS_TAG is passed, and it is
     # pulled with `docker compose pull`.
     image: ghcr.io/hakwerk/labca-boulder:${LABCA_IMAGE_VERSION:-latest}
+    # Published LabCA images are currently amd64-only in GHCR.
+    platform: ${LABCA_IMAGE_PLATFORM:-linux/amd64}
     build:
       context: test/boulder-tools/
       # Should match one of the GO_CI_VERSIONS in test/boulder-tools/tag_and_upload.sh.
@@ -13,8 +15,8 @@ services:
     environment:
       # To solve HTTP-01 and TLS-ALPN-01 challenges, change the IP in FAKE_DNS
       # to the IP address where your ACME client's solver is listening. This is
-      # pointing at the boulder service's "public" IP, where challtestsrv is.
-      FAKE_DNS: 64.112.117.122
+      # pointing at the nginx service IP where certbot's webroot challenges are served.
+      FAKE_DNS: ${LABCA_FAKE_DNS:-10.77.77.9}
       BOULDER_CONFIG_DIR: labca/config
       USE_VITESS: false
       GOCACHE: /boulder/.gocache/go-build
@@ -152,6 +154,7 @@ services:
 
   gui:
     image: ghcr.io/hakwerk/labca-gui:${LABCA_IMAGE_VERSION:-latest}
+    platform: ${LABCA_IMAGE_PLATFORM:-linux/amd64}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.yml:/opt/boulder/docker-compose.yml
@@ -180,7 +183,10 @@ services:
   nginx:
     image: nginx:latest
     networks:
-      - bouldernet
+      bouldernet:
+        ipv4_address: 10.77.77.9
+        aliases:
+          - labca.localhost
     ports:
       - 80:80
       - 443:443
@@ -194,6 +200,7 @@ services:
 
   control:
     image: ghcr.io/hakwerk/labca-control:${LABCA_IMAGE_VERSION:-latest}
+    platform: ${LABCA_IMAGE_PLATFORM:-linux/amd64}
     networks:
       - bouldernet
     volumes:

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,7 +2,8 @@
 include conf.d/custom-base[.]inc;
 
 server {
-    listen [::]:80 default_server ipv6only=off;
+    listen 80 default_server;
+    listen [::]:80 default_server;
     server_name _;
     server_tokens off;
 
@@ -49,7 +50,8 @@ server {
 }
 
 server {
-    listen [::]:443 default_server ssl ipv6only=off;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
     server_name _;
     server_tokens off;
 


### PR DESCRIPTION
## Summary
- add amd64 platform overrides for `boulder`, `gui`, and `control` images so LabCA can run on ARM64 hosts with emulation
- make `FAKE_DNS` configurable and default it to nginx static IP (`10.77.77.9`) to support HTTP-01 validation routing
- give nginx a static bouldernet IP and FQDN alias (`labca.localhost`) for stable ACME challenge resolution
- replace `ipv6only=off` listeners with explicit IPv4+IPv6 listen directives in `nginx.conf`
- document `LABCA_IMAGE_PLATFORM` and `LABCA_FAKE_DNS` in `build/.env.sample`

## Validation Results
- ✅ `go test -C gui ./...` (no test files)
- ✅ `go test -C gui -tags standalone ./...` (no test files)
- ✅ `golangci-lint run` in official container (`0 issues`)
- ✅ `make build`
- ✅ `DOCKER_DEFAULT_PLATFORM=linux/amd64 bash build/build.sh`
- ⚠️ `make debian` failed locally: missing `debhelper (>= 10)`
- ⚠️ `make debian-arm64` failed locally: missing `debhelper (>= 10)`
- ✅ runtime smoke checks: all services `Up` in `docker compose ps`; `https://127.0.0.1/admin/login` returns `200`

## Notes
- initial `build/build.sh` run without amd64 default platform failed on arm64 manifest for `letsencrypt/boulder-tools`; rerun with amd64 emulation succeeded
- conversation context: https://app.warp.dev/conversation/b78264f0-33c0-472b-a40d-51fae04af879

Co-Authored-By: Oz <oz-agent@warp.dev>
